### PR TITLE
README file suffix fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README'), encoding='utf-8') as f:
+with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
Adding the missing ".rst" at README file path